### PR TITLE
remove arybase.pm dependancy on perl5.16

### DIFF
--- a/lib/Win32/Unicode/File.pm
+++ b/lib/Win32/Unicode/File.pm
@@ -177,7 +177,7 @@ sub _readline {
     }
 
     my $line = '';
-    while (index($line, $/) == $[ -1) {
+    while (index($line, $/) == -1) {
         my $char = $self->getc;
         last if not defined $char or $char eq '';
         $line .= $char;


### PR DESCRIPTION
Since $[ is always zero, "$[ -1)" can be written "-1", and so perl 5.16 won't require arybase.pm (otherwise it must be explicitly loaded - use arybase - in order to get perl compilation working)
