### PR TITLE
Strawberry Perl 5.18.4でもテストがパスするようにしてみました

### DIFF
--- a/t/04_print.t
+++ b/t/04_print.t
@@ -7,6 +7,11 @@ use Test::Output;
 use Win32::Unicode;
 use File::Spec;
 
+BEGIN {
+    binmode STDOUT, ':encoding(utf8)';
+    binmode STDERR, ':encoding(utf8)';
+}
+
 open STDERR, '>', File::Spec->devnull or die $!;
 
 my $str = " I \x{2665} Perl";

--- a/xs/File.xs
+++ b/xs/File.xs
@@ -36,6 +36,9 @@ create_file(WCHAR *filename, long amode, long smode, long opt, long attr)
             attr,
             NULL
         );
+        if (RETVAL == INVALID_HANDLE_VALUE) {
+            XSRETURN_IV(-1);
+        }
     OUTPUT:
         RETVAL
 


### PR DESCRIPTION
こんにちは。

Strawberry Perl 5.18.4(32bit)でもテスト(t/04_print.t、t/10_read.t)がパスするようにしてみました。

以前テストに失敗していたテストレポートは
http://www.cpantesters.org/cpan/report/9b159fbe-6c4a-1014-b5a9-64d8233a935b
です。

32bit版しか確認できてませんがStrawberry Perlのバージョンによっては、
INVALID_HANDLE_VALUEは、-1または0xFFFFFFFFをとるようでした。

Win32::Unicodeが5.18.x以上で動くようになるととてもうれしいです！

よろしくお願いいたします。

--
twata
